### PR TITLE
Salto Deployment: Restoring SFDC - Zalary Dev to February 29th at 11:55 am

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+## [Restoring SFDC - Zalary Dev to February 29th at 11:55 am](https://app.salto.io/orgs/bb6cb5ce-46ed-4afe-918e-35bf269875f5/envs/000934b6-d409-4c11-a0bc-3c3a454a8f24/deployments/0a95e522-fade-453d-852d-3ccc7f9ced2f)
+
+Source: snapshot from 02/29/2024 @ 5:56 pm of the target environment
+
+Target Environment: [SFDC - Zalary Dev](https://app.salto.io/orgs/bb6cb5ce-46ed-4afe-918e-35bf269875f5/envs/000934b6-d409-4c11-a0bc-3c3a454a8f24) 
+
+Author: Zalary Young
+
+To include additional edits in this deployment, commit edits to the PR after branch.

--- a/envs/SFDC - Zadmin/salesforce/Records/EmailTemplate/unfiled_public_ZGY_Lead_Mail_1709228126391.nacl
+++ b/envs/SFDC - Zadmin/salesforce/Records/EmailTemplate/unfiled_public_ZGY_Lead_Mail_1709228126391.nacl
@@ -10,5 +10,5 @@ salesforce.EmailTemplate unfiled_public_ZGY_Lead_Mail_1709228126391@zcduuu {
   fullName = "unfiled$public/ZGY_Lead_Mail_1709228126391"
   content = file("salesforce/Records/EmailTemplate/unfiled$public/ZGY_Lead_Mail_1709228126391/ZGY_Lead_Mail_1709228126391.email")
   _alias = "unfiled$public/ZGY_Lead_Mail_1709228126391"
-  description = "unknown if this is classic or lightning"
+  
 }

--- a/envs/SFDC - Zadmin/static-resources/salesforce/Records/EmailTemplate/unfiled$public/ZGY_Lead_Mail_1709228126391/ZGY_Lead_Mail_1709228126391.email
+++ b/envs/SFDC - Zadmin/static-resources/salesforce/Records/EmailTemplate/unfiled$public/ZGY_Lead_Mail_1709228126391/ZGY_Lead_Mail_1709228126391.email
@@ -4,7 +4,7 @@
 </head>
 <body style="height: auto; min-height: auto;">Hello New Lead,<br />
 <br />
-You look nice today.&nbsp;<br />
+Thank you for being a lead.&nbsp;&nbsp;<br />
 <br />
-Updates Updates Updates</body>
+You look nice today.&nbsp;</body>
 </html>


### PR DESCRIPTION

Salto [deployment](https://app.salto.io/orgs/bb6cb5ce-46ed-4afe-918e-35bf269875f5/envs/000934b6-d409-4c11-a0bc-3c3a454a8f24/deployments/0a95e522-fade-453d-852d-3ccc7f9ced2f) from a snapshot at 02/29/2024 @ 5:56 pm to SFDC - Zalary Dev.




